### PR TITLE
 [WIP] Improved ranking of codeassist proposals 

### DIFF
--- a/plugins/org.eclipse.php.core/src/org/eclipse/php/internal/core/codeassist/strategies/AbstractClassInstantiationStrategy.java
+++ b/plugins/org.eclipse.php.core/src/org/eclipse/php/internal/core/codeassist/strategies/AbstractClassInstantiationStrategy.java
@@ -70,7 +70,9 @@ public abstract class AbstractClassInstantiationStrategy extends
 				// ParameterGuessingProposal
 				IMethod ctorMethod = FakeConstructor.createFakeConstructor(
 						null, type, type.equals(enclosingClass));
-				reporter.reportMethod(ctorMethod, suffix, replaceRange);
+
+				reporter.reportMethod(ctorMethod, suffix, replaceRange,
+						type.getFullyQualifiedName());
 			} else {
 				// if this is context information mode,we use this,
 				// because the number of types' length is very small
@@ -86,6 +88,7 @@ public abstract class AbstractClassInstantiationStrategy extends
 			}
 
 		}
+
 		addAlias(reporter, suffix);
 	}
 
@@ -106,13 +109,15 @@ public abstract class AbstractClassInstantiationStrategy extends
 
 		char nextChar = ' ';
 		try {
-			if(insertMode){
+			if (insertMode) {
 				nextChar = abstractContext.getNextChar();
-			}else{
+			} else {
 				SourceRange replacementRange = getReplacementRange(abstractContext);
-				nextChar = abstractContext.getDocument().getChar(replacementRange.getOffset()+replacementRange.getLength());
+				nextChar = abstractContext.getDocument().getChar(
+						replacementRange.getOffset()
+								+ replacementRange.getLength());
 			}
-			
+
 		} catch (BadLocationException e) {
 			PHPCorePlugin.log(e);
 		}

--- a/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/configuration/PHPStructuredTextViewerConfiguration.java
+++ b/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/configuration/PHPStructuredTextViewerConfiguration.java
@@ -20,9 +20,7 @@ import org.eclipse.dltk.internal.ui.typehierarchy.HierarchyInformationControl;
 import org.eclipse.dltk.ui.actions.IScriptEditorActionDefinitionIds;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.*;
-import org.eclipse.jface.text.contentassist.ContentAssistant;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
-import org.eclipse.jface.text.contentassist.IContentAssistant;
+import org.eclipse.jface.text.contentassist.*;
 import org.eclipse.jface.text.formatter.IContentFormatter;
 import org.eclipse.jface.text.formatter.MultiPassContentFormatter;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
@@ -44,8 +42,10 @@ import org.eclipse.php.internal.ui.autoEdit.IndentLineAutoEditStrategy;
 import org.eclipse.php.internal.ui.autoEdit.MainAutoEditStrategy;
 import org.eclipse.php.internal.ui.doubleclick.PHPDoubleClickStrategy;
 import org.eclipse.php.internal.ui.editor.PHPStructuredTextViewer;
+import org.eclipse.php.internal.ui.editor.contentassist.CompletionRelevanceComputer;
 import org.eclipse.php.internal.ui.editor.contentassist.PHPCompletionProcessor;
 import org.eclipse.php.internal.ui.editor.contentassist.PHPContentAssistant;
+import org.eclipse.php.internal.ui.editor.contentassist.ParameterGuessingProposal;
 import org.eclipse.php.internal.ui.editor.highlighter.LineStyleProviderForPhp;
 import org.eclipse.php.internal.ui.editor.hover.BestMatchHover;
 import org.eclipse.php.internal.ui.editor.hover.PHPTextHoverProxy;
@@ -218,6 +218,37 @@ public class PHPStructuredTextViewerConfiguration extends
 				fContentAssistant.uninstall();
 			}
 			fContentAssistant = new PHPContentAssistant();
+
+			fContentAssistant.addCompletionListener(new ICompletionListener() {
+
+				private String currentSelection;
+
+				public void selectionChanged(ICompletionProposal proposal,
+						boolean smartToggle) {
+
+					if (proposal instanceof ParameterGuessingProposal) {
+						ParameterGuessingProposal scriptProposal = (ParameterGuessingProposal) proposal;
+
+						if (scriptProposal.getExtraInfo() != null
+								&& scriptProposal.getExtraInfo() instanceof String) {
+							currentSelection = (String) scriptProposal
+									.getExtraInfo();
+						}
+					}
+				}
+
+				public void assistSessionStarted(ContentAssistEvent event) {
+
+				}
+
+				public void assistSessionEnded(ContentAssistEvent event) {
+
+					if (currentSelection != null) {
+						CompletionRelevanceComputer.getInstance()
+								.incrementTypeProposal(currentSelection);
+					}
+				}
+			});
 
 			// content assistant configurations
 			fContentAssistant

--- a/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/contentassist/CompletionRelevanceComputer.java
+++ b/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/contentassist/CompletionRelevanceComputer.java
@@ -1,0 +1,43 @@
+package org.eclipse.php.internal.ui.editor.contentassist;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CompletionRelevanceComputer {
+
+	protected static CompletionRelevanceComputer instance;
+
+	protected Map<String, Integer> typeProposals = new HashMap<String, Integer>();
+
+	private CompletionRelevanceComputer() {
+
+	}
+
+	public static CompletionRelevanceComputer getInstance() {
+		if (instance == null) {
+			instance = new CompletionRelevanceComputer();
+		}
+
+		return instance;
+	}
+
+	public void incrementTypeProposal(String fullyQualifiedName) {
+
+		if (!typeProposals.containsKey(fullyQualifiedName)) {
+			typeProposals.put(fullyQualifiedName, new Integer(1));
+			return;
+		}
+
+		Integer curr = typeProposals.get(fullyQualifiedName);
+		typeProposals.put(fullyQualifiedName, curr + 1);
+	}
+
+	public Integer getTypeRelevance(String fullyQualifiedName) {
+
+		if (!typeProposals.containsKey(fullyQualifiedName)) {
+			return 1;
+		}
+
+		return typeProposals.get(fullyQualifiedName);
+	}
+}

--- a/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/contentassist/PHPCompletionProposalCollector.java
+++ b/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/editor/contentassist/PHPCompletionProposalCollector.java
@@ -309,6 +309,14 @@ public class PHPCompletionProposalCollector extends
 
 	@Override
 	public int computeRelevance(CompletionProposal proposal) {
+
+		if (proposal.getExtraInfo() != null
+				&& proposal.getExtraInfo() instanceof String) {
+			Integer relevance = CompletionRelevanceComputer.getInstance()
+					.getTypeRelevance((String) proposal.getExtraInfo());
+			return proposal.getRelevance() * relevance;
+		}
+
 		// if (ProposalExtraInfo.STUB.equals(proposal.getExtraInfo())) {
 		// return Integer.MAX_VALUE;
 		// }


### PR DESCRIPTION
In projects with a high number of vendor libraries, codeassist proposal often have quite a large number of similar entries in different namespaces. For example in Symfony2 + a couple of bundles, when completing the type `User` you can have a list of 5 - 15 entries in codeassist, but the one from your bundle is alphabetically one of the last entries.

Each time you get codeassist for `User` type, you have to scroll down to the one you actually need.

This PR is a first sketch on how this could be improved by using the number of times the user has selected an entry as the base for computing the relevance of each entry. Entries that have been selected more often are automatically sorted higher in the list:
- First trigger of codeassist for the `User` type: [screenshot](https://dl.dropbox.com/u/8251167/Screen%20Shot%202012-10-30%20at%2000.16.16%20.png)
- Second trigger of codeassist for the `User` type: [screenshot](https://dl.dropbox.com/u/8251167/Screen%20Shot%202012-10-30%20at%2000.16.40%20.png)

This is not yet meant to be merged, just a proposal. If you think this approach makes sense, i can give this PR more detailed treatment.
