### PR TITLE
added possibibility to restrict PHP versions to a minimum version in the configBlock

### DIFF
--- a/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/preferences/PHPVersionConfigurationBlock.java
+++ b/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/preferences/PHPVersionConfigurationBlock.java
@@ -55,6 +55,8 @@ public class PHPVersionConfigurationBlock extends
 	protected Button useShortTagsButton;
 	protected Label nameLabel;
 
+	protected PHPVersion minimumVersion = null;
+
 	private boolean hideShortTags;
 
 	public PHPVersionConfigurationBlock(IStatusChangeListener context,
@@ -67,6 +69,10 @@ public class PHPVersionConfigurationBlock extends
 			boolean hideShortTags) {
 		this(context, project, container);
 		this.hideShortTags = hideShortTags;
+	}
+
+	public void setMinimumVersion(PHPVersion version) {
+		this.minimumVersion = version;
 	}
 
 	public void setEnabled(boolean isEnabled) {
@@ -182,6 +188,11 @@ public class PHPVersionConfigurationBlock extends
 	private List prepareVersionEntryList() {
 		ArrayList entryList = new ArrayList();
 		for (int i = 0; i < PHP_VERSION_DESCRIPTIONS.length; i++) {
+			if (minimumVersion != null
+					&& PHPVersion.byAlias(PHP_VERSION_VALUES[i]).isLessThan(
+							minimumVersion)) {
+				continue;
+			}
 			String description = PHP_VERSION_DESCRIPTIONS[i];
 			String value = PHP_VERSION_VALUES[i];
 			Entry entry = new ValuedCombo.Entry(value, description);

--- a/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/wizards/PHPProjectWizardFirstPage.java
+++ b/plugins/org.eclipse.php.ui/src/org/eclipse/php/internal/ui/wizards/PHPProjectWizardFirstPage.java
@@ -112,7 +112,7 @@ public class PHPProjectWizardFirstPage extends WizardPage implements
 		fragment = (WizardFragment) Platform.getAdapterManager().loadAdapter(
 				data, PHPProjectWizardFirstPage.class.getName());
 
-		fVersionGroup = new VersionGroup(composite);
+		fVersionGroup = new VersionGroup(composite, PHPVersion.PHP4);
 		fLayoutGroup = new LayoutGroup(composite);
 		fJavaScriptSupportGroup = new JavaScriptSupportGroup(composite, this);
 
@@ -526,7 +526,7 @@ public class PHPProjectWizardFirstPage extends WizardPage implements
 				+ ".last.external.project"; //$NON-NLS-1$
 		private Link fPreferenceLink;
 
-		public VersionGroup(Composite composite) {
+		public VersionGroup(Composite composite, PHPVersion minimumVersion) {
 			final int numColumns = 3;
 			final Group group = new Group(composite, SWT.NONE);
 			group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -553,6 +553,7 @@ public class PHPProjectWizardFirstPage extends WizardPage implements
 						public void statusChanged(IStatus status) {
 						}
 					}, (IProject) null, null);
+			fConfigurationBlock.setMinimumVersion(minimumVersion);
 			fConfigurationBlock.createContents(group);
 			fConfigurationBlock.setEnabled(false);
 			// fPreferenceLink = new Link(fGroup, SWT.NONE);


### PR DESCRIPTION
Some PHP libraries might need to restrict the available PHP versions for new projects to a certain minimum version range (e.g. https://github.com/pulse00/Symfony-2-Eclipse-Plugin/commit/97d37b3ce18947d3f56be0899d3d35af9984737a). 

This PR adds the possibility to the `PHPVersionConfigurationBlock`.
