### PR TITLE
Minor fixes and improvements

### DIFF
--- a/plugins/org.eclipse.php.phpunit/resources/printer/PHPUnitLogger.php
+++ b/plugins/org.eclipse.php.phpunit/resources/printer/PHPUnitLogger.php
@@ -27,6 +27,7 @@ if (class_exists('PHPUnit_Util_Printer')) {
     class_alias('PHPUnit\Framework\AssertionFailedError', 'AssertionFailedError');
     class_alias('PHPUnit\Framework\Exception', 'Exception2');
     class_alias('PHPUnit\Framework\ExpectationFailedException', 'ExpectationFailedException');
+    class_alias('PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning');
 }
 
 class PHPUnitLogger extends Printer implements TestListener
@@ -47,10 +48,7 @@ class PHPUnitLogger extends Printer implements TestListener
     {
         $this->cleanTest();
         
-        $port = $_SERVER['ZEND_PHPUNIT_PORT'];
-        if (! isset($port)) {
-            $port = 7478;
-        }
+        $port = isset($_SERVER['ZEND_PHPUNIT_PORT']) ? $_SERVER['ZEND_PHPUNIT_PORT'] : 7478;
         $this->out = fsockopen('127.0.0.1', $port, $errno, $errstr, 5);
     }
     
@@ -415,7 +413,7 @@ class ZendPHPUnitErrorHandler
             
             else
                 if ($errno == E_NOTICE) {
-                    trigger_error($errstr, E_USER_NOTICE);
+                    trigger_error(sprintf("%s:%d:%s", $errfile, $errline, $errstr), E_USER_NOTICE);
                     return FALSE;
                 }
             


### PR DESCRIPTION
I found an error, where class PHPUnit_Framework_Error_Warning could not be found while using PHPUnit 6.

Then it was necessary to use breakpoints in case of a E_NOTICE to find the source of problem, so I decided to extend the output of trigger_error.

Finally, the index $_SERVER['ZEND_PHPUNIT_PORT'] could not be found, which caused an error while executing the PHPUnit plugin, so I changed the check for it.