### PR TITLE
Fix for GitHub issue #93 by including cases for PHP v7.3 and 7.4

### DIFF
--- a/plugins/org.eclipse.php.core/src/org/eclipse/php/internal/core/language/DefaultLanguageModelProvider.java
+++ b/plugins/org.eclipse.php.core/src/org/eclipse/php/internal/core/language/DefaultLanguageModelProvider.java
@@ -73,7 +73,13 @@ class DefaultLanguageModelProvider implements ILanguageModelProvider {
 		if (phpVersion == PHPVersion.PHP7_2) {
 			return LANGUAGE_LIBRARY_PATH + "7.2"; //$NON-NLS-1$
 		}
-		return LANGUAGE_LIBRARY_PATH + "7.3"; //$NON-NLS-1$
+		if (phpVersion == PHPVersion.PHP7_3) {
+			return LANGUAGE_LIBRARY_PATH + "7.3"; //$NON-NLS-1$
+		}
+		if (phpVersion == PHPVersion.PHP7_4) {
+			return LANGUAGE_LIBRARY_PATH + "7.4"; //$NON-NLS-1$
+		}
+		return LANGUAGE_LIBRARY_PATH + "7.4"; //$NON-NLS-1$
 	}
 
 	@Override


### PR DESCRIPTION
I encountered the issue described in #93 and fixed it by adding extra checks for PHP versions 7.3 and 7.4. I built and tested the plugin in Eclipse and it now works properly for features new to PHP 7.4 like WeakReference.

I've also updated the default return to PHP 7.4.

This is my first commit to this project but I have already previously signed the Eclipse Contributor Agreement (ECA) and I have tried to follow the contrib guidelines e.g. signing my commit. Hope all is OK.