### PR TITLE
Fix #134 - Add missing feature to current target platform

### DIFF
--- a/dev/org.eclipse.php.target.current/org.eclipse.php.target.current.target
+++ b/dev/org.eclipse.php.target.current/org.eclipse.php.target.current.target
@@ -53,6 +53,10 @@
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/cbi/updates/license"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.0/"/>
+<unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.0.0"/>
+</location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>


### PR DESCRIPTION
Add missing feature  "org.eclipse.wildwebdeveloper.feature.feature.group" to current target platform

Signed-off-by: Markus Hoffrogge <mhoffrogge@gmail.com>