### PR TITLE
Correct syntax for require in refactoring help file.

### DIFF
--- a/plugins/org.eclipse.php.help/docs/source/008-getting_started/016-basic_tutorial/020-working_with_refactoring.md
+++ b/plugins/org.eclipse.php.help/docs/source/008-getting_started/016-basic_tutorial/020-working_with_refactoring.md
@@ -45,7 +45,7 @@ This procedure demonstrates how to rename a file:
 2. In the same project, create a second PHP file, called RenFile2, with the following code:
 
     <?php
-    require("RenFile1.php");
+    require_once("RenFile1.php");
     $a = 8;
     ?>
 
@@ -59,7 +59,7 @@ This procedure demonstrates how to rename a file:
 
 The reference to RenFile1 in RenFile2 will have been updated to:
 
-    require("RenFile3.php");
+    require_once("RenFile3.php");
 
 in order to reflect the changes in the file name.
 

--- a/plugins/org.eclipse.php.help/docs/source/008-getting_started/016-basic_tutorial/020-working_with_refactoring.md
+++ b/plugins/org.eclipse.php.help/docs/source/008-getting_started/016-basic_tutorial/020-working_with_refactoring.md
@@ -45,7 +45,7 @@ This procedure demonstrates how to rename a file:
 2. In the same project, create a second PHP file, called RenFile2, with the following code:
 
     <?php
-    require(RenFile1.php);
+    require("RenFile1.php");
     $a = 8;
     ?>
 
@@ -59,7 +59,7 @@ This procedure demonstrates how to rename a file:
 
 The reference to RenFile1 in RenFile2 will have been updated to:
 
-    require(RenFile3.php);
+    require("RenFile3.php");
 
 in order to reflect the changes in the file name.
 


### PR DESCRIPTION
Fixes #139.

As noted in #139 the current documentation is wrong `require(RenFile1.php);` will error as it will be evaluated as two undefined constants (`RenFile1` and `php`) and the concatenation operator (`.`) which will cause a warning about each undefined constant and it will then try to concatenate these undefined constants. It will then try to require the file `RenFile1php` which will raise a fatal error (because using `require`, rather than `include`). Definitely more than unhelpful if the IDE help files don't use correct syntax for the examples!

`require` in PHP is a language level feature not a function, but I didn't update the syntax to the more usual `require "file.php"` because the function-like syntax is also acceptable.