### PR TITLE
Remove unused import org.eclipse.ui.views.navigator.ResourceSorter

### DIFF
--- a/plugins/org.eclipse.php.debug.ui/src/org/eclipse/php/internal/debug/ui/launching/TreeAndListGroup.java
+++ b/plugins/org.eclipse.php.debug.ui/src/org/eclipse/php/internal/debug/ui/launching/TreeAndListGroup.java
@@ -24,7 +24,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Tree;
-import org.eclipse.ui.views.navigator.ResourceSorter;
 
 /**
  * This class was derived from
@@ -48,9 +47,9 @@ public class TreeAndListGroup implements ISelectionChangedListener {
 	private boolean allowMultiselection = false;
 
 	/**
-	 * Create an instance of this class. Use this constructor if you wish to specify
-	 * the width and/or height of the combined widget (to only hardcode one of the
-	 * sizing dimensions, specify the other dimension's value as -1)
+	 * Create an instance of this class. Use this constructor if you wish to
+	 * specify the width and/or height of the combined widget (to only hardcode
+	 * one of the sizing dimensions, specify the other dimension's value as -1)
 	 * 
 	 * @param parent
 	 *            org.eclipse.swt.widgets.Composite
@@ -94,8 +93,8 @@ public class TreeAndListGroup implements ISelectionChangedListener {
 	}
 
 	/**
-	 * Add the passed listener to collection of clients that listen for changes to
-	 * list viewer selection state
+	 * Add the passed listener to collection of clients that listen for changes
+	 * to list viewer selection state
 	 * 
 	 * @param listener
 	 *            ISelectionChangedListener
@@ -127,8 +126,8 @@ public class TreeAndListGroup implements ISelectionChangedListener {
 	}
 
 	/**
-	 * Notify all double click listeners that a double click event has occurred in
-	 * the list viewer
+	 * Notify all double click listeners that a double click event has occurred
+	 * in the list viewer
 	 */
 	protected void notifyDoubleClickListeners(DoubleClickEvent event) {
 		Iterator<IDoubleClickListener> iter = doubleClickListeners.iterator();
@@ -257,7 +256,8 @@ public class TreeAndListGroup implements ISelectionChangedListener {
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(
+	 * @see
+	 * org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(
 	 * org.eclipse.jface.viewers.SelectionChangedEvent)
 	 */
 	@Override
@@ -299,8 +299,8 @@ public class TreeAndListGroup implements ISelectionChangedListener {
 	}
 
 	/**
-	 * Set the root of the widget to be new Root. Regenerate all of the tables and
-	 * lists from this value.
+	 * Set the root of the widget to be new Root. Regenerate all of the tables
+	 * and lists from this value.
 	 * 
 	 * @param newRoot
 	 */


### PR DESCRIPTION
This class has been deleted from 4.28 and isn't used.